### PR TITLE
Fix DDM validator hoisting nested required fields to top-level

### DIFF
--- a/crates/profile/src/cli/ddm.rs
+++ b/crates/profile/src/cli/ddm.rs
@@ -173,6 +173,59 @@ struct DdmValidationResult {
     warnings: Vec<String>,
 }
 
+/// Resolve the ancestor path for a nested field by walking `parent_key` links.
+///
+/// Returns the chain from root to immediate parent, e.g. for `AddSquareRoot`
+/// (parent=`BasicMode`, whose parent=`Calculator`) returns `["Calculator", "BasicMode"]`.
+fn resolve_ancestor_path(
+    field_name: &str,
+    manifest: &crate::schema::types::PayloadManifest,
+) -> Vec<String> {
+    let mut path = Vec::new();
+    let mut current = field_name.to_string();
+
+    for _ in 0..32 {
+        let parent = manifest
+            .fields
+            .get(&current)
+            .and_then(|f| f.parent_key.as_ref());
+        match parent {
+            Some(p) => {
+                path.push(p.clone());
+                current = p.clone();
+            }
+            None => break,
+        }
+    }
+
+    path.reverse();
+    path
+}
+
+/// Walk into a payload along the given key path.
+///
+/// The root is a `HashMap` (DeclarationPayload), but nested levels are
+/// `serde_json::Map` inside `Value::Object`. Returns the innermost object
+/// if every key in the path resolves, or `None` if any key is absent or
+/// not an object.
+fn walk_payload_path<'a>(
+    root: &'a std::collections::HashMap<String, serde_json::Value>,
+    path: &[String],
+) -> Option<&'a serde_json::Map<String, serde_json::Value>> {
+    let (first, rest) = path.split_first()?;
+    let serde_json::Value::Object(obj) = root.get(first)? else {
+        return None;
+    };
+    let mut current = obj;
+    for key in rest {
+        match current.get(key) {
+            Some(serde_json::Value::Object(nested)) => current = nested,
+            _ => return None,
+        }
+    }
+    Some(current)
+}
+
 /// Validate a single DDM declaration
 fn validate_single_ddm(path: &Path, registry: &SchemaRegistry) -> Result<DdmValidationResult> {
     let decl = parse_declaration_file(path)?;
@@ -184,8 +237,21 @@ fn validate_single_ddm(path: &Path, registry: &SchemaRegistry) -> Result<DdmVali
     if let Some(manifest) = registry.get(&decl.declaration_type) {
         // Check required fields
         for field in manifest.required_fields() {
-            if decl.payload.get(&field.name).is_none() {
-                errors.push(format!("Missing required field: {}", field.name));
+            if field.depth == 0 {
+                if decl.payload.get(&field.name).is_none() {
+                    errors.push(format!("Missing required field: {}", field.name));
+                }
+            } else if field.parent_key.is_some() {
+                let ancestors = resolve_ancestor_path(&field.name, manifest);
+                if let Some(parent_obj) = walk_payload_path(&decl.payload.0, &ancestors) {
+                    if !parent_obj.contains_key(&field.name) {
+                        let full_path = ancestors.join(".");
+                        errors.push(format!(
+                            "Missing required field: {full_path}.{}",
+                            field.name
+                        ));
+                    }
+                }
             }
         }
 

--- a/crates/profile/src/schema/jsonschema.rs
+++ b/crates/profile/src/schema/jsonschema.rs
@@ -404,6 +404,7 @@ mod tests {
             default: Some("default".to_string()),
             allowed_values: vec![],
             depth: 0,
+            parent_key: None,
             platforms: vec![],
             min_version: None,
         };
@@ -421,6 +422,7 @@ mod tests {
             default: None,
             allowed_values: vec![],
             depth: 0,
+            parent_key: None,
             platforms: vec![],
             min_version: None,
         };
@@ -438,6 +440,7 @@ mod tests {
             default: None,
             allowed_values: vec![],
             depth: 0,
+            parent_key: None,
             platforms: vec![],
             min_version: None,
         };

--- a/crates/profile/src/schema/loader.rs
+++ b/crates/profile/src/schema/loader.rs
@@ -65,6 +65,7 @@ pub fn load_embedded() -> Result<Vec<PayloadManifest>> {
                             })
                             .unwrap_or_default(),
                         depth: f.depth,
+                        parent_key: None,
                         platforms: f
                             .platforms
                             .as_ref()
@@ -190,6 +191,7 @@ fn supplemental_prefs_manifests() -> Vec<PayloadManifest> {
                     default: None,
                     allowed_values: Vec::new(),
                     depth: 0,
+                    parent_key: None,
                     platforms: vec![Platform::MacOS],
                     min_version: None,
                 },
@@ -301,6 +303,7 @@ fn capability_to_manifest(cap: &mdm_schema::Capability) -> PayloadManifest {
             default: key.default_value.as_ref().map(|v| v.to_string()),
             allowed_values: key.range_list.clone().unwrap_or_default(),
             depth: key.depth as u8,
+            parent_key: key.parent_key.clone(),
             platforms: Vec::new(),
             min_version: None,
         };

--- a/crates/profile/src/schema/parser.rs
+++ b/crates/profile/src/schema/parser.rs
@@ -176,6 +176,7 @@ fn parse_ddm_key_line(line: &str) -> Result<FieldDefinition> {
         default: None,
         allowed_values: Vec::new(),
         depth: 0,
+        parent_key: None,
         platforms: Vec::new(),
         min_version: None,
     })
@@ -319,6 +320,7 @@ fn parse_key_line(line: &str) -> Result<FieldDefinition> {
         default,
         allowed_values,
         depth,
+        parent_key: None,
         platforms,
         min_version,
     })

--- a/crates/profile/src/schema/plist_parser.rs
+++ b/crates/profile/src/schema/plist_parser.rs
@@ -320,6 +320,7 @@ fn parse_field(dict: &plist::Dictionary, depth: usize) -> Option<FieldDefinition
         default,
         allowed_values,
         depth: depth as u8,
+        parent_key: None,
         platforms: Vec::new(),
         min_version: None,
     })

--- a/crates/profile/src/schema/types.rs
+++ b/crates/profile/src/schema/types.rs
@@ -92,6 +92,8 @@ pub struct FieldDefinition {
     pub allowed_values: Vec<String>,
     /// Nesting depth (0=top-level, 1=first nested, etc.)
     pub depth: u8,
+    /// Parent key name for nested fields (e.g. "CustomRegex" for a "Regex" child key)
+    pub parent_key: Option<String>,
     /// Platform-specific (empty = all platforms)
     pub platforms: Vec<Platform>,
     /// Minimum version requirement
@@ -467,6 +469,7 @@ mod tests {
                 default: None,
                 allowed_values: vec![],
                 depth: 0,
+                parent_key: None,
                 platforms: vec![],
                 min_version: None,
             },
@@ -489,6 +492,7 @@ mod tests {
                 default: None,
                 allowed_values: vec![],
                 depth: 0,
+                parent_key: None,
                 platforms: vec![],
                 min_version: None,
             },
@@ -507,6 +511,7 @@ mod tests {
                 default: None,
                 allowed_values: vec![],
                 depth: 1,
+                parent_key: None,
                 platforms: vec![],
                 min_version: None,
             },

--- a/crates/profile/src/schema/yaml_parser.rs
+++ b/crates/profile/src/schema/yaml_parser.rs
@@ -286,6 +286,7 @@ fn parse_yaml_manifest_simplified(content: &str) -> Result<PayloadManifest> {
                 default: None,
                 allowed_values: Vec::new(),
                 depth: 0,
+                parent_key: None,
                 platforms: Vec::new(),
                 min_version: None,
             };
@@ -584,6 +585,7 @@ fn parse_apple_field(field: &AppleField, depth: usize) -> FieldDefinition {
         default,
         allowed_values,
         depth: depth as u8,
+        parent_key: None,
         platforms: Vec::new(),
         min_version: None,
     }

--- a/crates/profile/src/validation/schema_validator.rs
+++ b/crates/profile/src/validation/schema_validator.rs
@@ -844,6 +844,7 @@ mod tests {
                     default: None,
                     allowed_values: Vec::new(),
                     depth: 0,
+                    parent_key: None,
                     platforms: Vec::new(),
                     min_version: None,
                 },


### PR DESCRIPTION
The validator was checking all required fields against the top-level payload regardless of nesting depth. A field like Regex (required inside the optional CustomRegex dictionary for https://github.com/apple/device-management/blob/release/declarative/declarations/configurations/passcode.settings.yaml) would fail validation even when CustomRegex was absent.

Adds parent_key to FieldDefinition and walks the full ancestor chain so nested required fields are only enforced when their parent dictionary is actually present in the payload. Supports arbitrary nesting depth.

<img width="1146" height="531" alt="Screenshot 2026-04-02 at 12 15 02 PM" src="https://github.com/user-attachments/assets/df263ec4-b74c-4136-9208-adc9f50b0800" />
