### PR TITLE
Bump version and add mscp fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,11 +87,11 @@ dirs = "6.0"
 mimalloc = "0.1"
 
 # Internal crates
-contour-core = { path = "crates/contour-core", version = "0.1.7" }
-contour-profiles = { path = "crates/contour-profiles", version = "0.1.7" }
-mdm-schema = { path = "crates/mdm-schema", version = "0.1.7" }
-mscp-schema = { path = "crates/mscp-schema", version = "0.1.7" }
-osquery-schema = { path = "crates/osquery-schema", version = "0.1.7" }
+contour-core = { path = "crates/contour-core", version = "0.1.8" }
+contour-profiles = { path = "crates/contour-profiles", version = "0.1.8" }
+mdm-schema = { path = "crates/mdm-schema", version = "0.1.8" }
+mscp-schema = { path = "crates/mscp-schema", version = "0.1.8" }
+osquery-schema = { path = "crates/osquery-schema", version = "0.1.8" }
 
 [workspace.dependencies.tempfile]
 version = "3.24"

--- a/crates/btm/Cargo.toml
+++ b/crates/btm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btm"
-version = "0.1.7"
+version = "0.1.8"
 description = "Background Task Management profile toolkit for macOS service management"
 edition.workspace = true
 authors.workspace = true

--- a/crates/contour-core/Cargo.toml
+++ b/crates/contour-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contour-core"
-version = "0.1.7"
+version = "0.1.8"
 description = "Shared library for Contour CLI tools (profile, mscp, santa)"
 edition.workspace = true
 authors.workspace = true

--- a/crates/contour-core/src/help_agents.rs
+++ b/crates/contour-core/src/help_agents.rs
@@ -1846,7 +1846,9 @@ pub fn install_skill(version: &str) -> Result<()> {
             let existing = fs::read_to_string(path)?;
             if existing.contains("contour — macOS MDM Configuration Toolkit") {
                 // Already has full content — replace the contour section
-                eprintln!("  {agent_file} already has contour instructions (use --force to replace)");
+                eprintln!(
+                    "  {agent_file} already has contour instructions (use --force to replace)"
+                );
             } else {
                 // Append full skill content
                 let mut updated = existing;

--- a/crates/contour-core/src/lib.rs
+++ b/crates/contour-core/src/lib.rs
@@ -34,8 +34,8 @@ pub use errors::{ContourError, ContourResult};
 pub use fleet_layout::{FleetLayout, FleetLayoutVersion};
 pub use logging::init_logging;
 pub use output::{
-    CommandResult, OutputMode, print_error, print_info, print_json, print_kv, print_success,
-    print_warning, resolve_output_dir, sanitize_filename,
+    CommandResult, OutputMode, format_elapsed, print_error, print_info, print_json, print_kv,
+    print_success, print_warning, resolve_output_dir, sanitize_filename,
 };
 pub use scan::{AppInfo, discover_apps, multi_select, select_apps};
 pub use string_utils::levenshtein_distance;

--- a/crates/contour-core/src/output.rs
+++ b/crates/contour-core/src/output.rs
@@ -8,6 +8,7 @@ use anyhow::Context;
 use colored::Colorize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::time::Duration;
 
 /// Output mode for CLI commands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -233,6 +234,25 @@ pub fn print_json<T: Serialize>(data: &T) -> anyhow::Result<()> {
     Ok(())
 }
 
+// ── Timing helpers ──────────────────────────────────────────────
+
+/// Format a duration as a human-readable elapsed time string.
+///
+/// Returns compact output: "1.23s", "456ms", or "1m 23s" for longer durations.
+#[must_use]
+pub fn format_elapsed(duration: Duration) -> String {
+    let secs = duration.as_secs_f64();
+    if secs < 1.0 {
+        format!("{}ms", duration.as_millis())
+    } else if secs < 60.0 {
+        format!("{secs:.2}s")
+    } else {
+        let mins = duration.as_secs() / 60;
+        let remaining = duration.as_secs() % 60;
+        format!("{mins}m {remaining}s")
+    }
+}
+
 // ── File-system helpers ─────────────────────────────────────────
 
 /// Sanitize an app name for use in a filename.
@@ -324,6 +344,24 @@ mod tests {
         assert_eq!(sanitize_filename("Zoom Workplace"), "zoom-workplace");
         assert_eq!(sanitize_filename("1Password 8"), "1password-8");
         assert_eq!(sanitize_filename("my_app-v2"), "my_app-v2");
+    }
+
+    #[test]
+    fn test_format_elapsed_millis() {
+        let d = Duration::from_millis(456);
+        assert_eq!(format_elapsed(d), "456ms");
+    }
+
+    #[test]
+    fn test_format_elapsed_seconds() {
+        let d = Duration::from_secs_f64(2.5);
+        assert_eq!(format_elapsed(d), "2.50s");
+    }
+
+    #[test]
+    fn test_format_elapsed_minutes() {
+        let d = Duration::from_secs(125);
+        assert_eq!(format_elapsed(d), "2m 5s");
     }
 
     #[test]

--- a/crates/contour-profiles/Cargo.toml
+++ b/crates/contour-profiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contour-profiles"
-version = "0.1.7"
+version = "0.1.8"
 description = "Shared mobileconfig profile building utilities for Contour tools"
 edition.workspace = true
 authors.workspace = true

--- a/crates/contour/Cargo.toml
+++ b/crates/contour/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contour"
-version = "0.1.7"
+version = "0.1.8"
 description = "Unified macOS MDM configuration toolkit"
 edition.workspace = true
 authors.workspace = true

--- a/crates/contour/src/dispatch.rs
+++ b/crates/contour/src/dispatch.rs
@@ -1762,6 +1762,7 @@ fn dispatch_mscp(action: mscp::cli::Commands, _verbose: bool, json: bool) -> Res
         }
 
         Commands::Generate {
+            config: config_path,
             mscp_repo,
             branch,
             baseline,
@@ -1797,10 +1798,6 @@ fn dispatch_mscp(action: mscp::cli::Commands, _verbose: bool, json: bool) -> Res
             script_mode,
             fragment,
         } => {
-            // Resolve org from CLI flags, falling back to .contour/config.toml
-            let org = resolve_mscp_org(org);
-            let org_name = resolve_mscp_org_name(org_name);
-
             let python_method = if use_container {
                 Some(mscp::cli::generate::PythonMethod::Container)
             } else if use_uv {
@@ -1810,6 +1807,69 @@ fn dispatch_mscp(action: mscp::cli::Commands, _verbose: bool, json: bool) -> Res
             } else {
                 None // Auto-detect
             };
+
+            // Config-driven generation: load mscp.toml, derive options for this baseline.
+            if let Some(config_file) = config_path {
+                let loaded_config = mscp::config::load_config(&config_file)?;
+
+                let baseline_config = loaded_config
+                    .baselines
+                    .iter()
+                    .find(|b| b.name == baseline)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "baseline '{}' not found in {}; available baselines: {}",
+                            baseline,
+                            config_file.display(),
+                            loaded_config
+                                .baselines
+                                .iter()
+                                .map(|b| b.name.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    })?;
+
+                let opts = mscp::cli::config_generate::build_options_from_config(
+                    &loaded_config,
+                    baseline_config,
+                );
+
+                if let Some(ref target_branch) = baseline_config.branch {
+                    mscp::cli::generate::switch_branch(&mscp_repo, target_branch)?;
+                } else if let Some(ref target_branch) = branch {
+                    mscp::cli::generate::switch_branch(&mscp_repo, target_branch)?;
+                }
+
+                mscp::cli::generate_baseline(
+                    mscp_repo,
+                    baseline,
+                    output,
+                    python_method,
+                    opts.profile_options,
+                    opts.jamf_options,
+                    opts.munki_compliance_options,
+                    opts.munki_script_options,
+                    opts.no_labels,
+                    opts.team_names,
+                    opts.fleet_mode,
+                    opts.jamf_exclude_conflicts,
+                    opts.generate_ddm,
+                    dry_run,
+                    output_mode,
+                    false, // batch_mode = false for single baseline
+                    script_mode.into(),
+                    exclude,
+                    fragment,
+                    opts.structure,
+                )?;
+                return Ok(());
+            }
+
+            // CLI-flag-driven generation (existing behavior when no --config)
+            // Resolve org from CLI flags, falling back to .contour/config.toml
+            let org = resolve_mscp_org(org);
+            let org_name = resolve_mscp_org_name(org_name);
             let deterministic_uuids = resolve_mscp_deterministic_uuids(deterministic_uuids);
 
             // Build ProfileOptions when any general profile option is set

--- a/crates/mdm-schema/Cargo.toml
+++ b/crates/mdm-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdm-schema"
-version = "0.1.7"
+version = "0.1.8"
 description = "MDM payload schema definitions"
 edition.workspace = true
 authors.workspace = true

--- a/crates/mscp-schema/Cargo.toml
+++ b/crates/mscp-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mscp-schema"
-version = "0.1.7"
+version = "0.1.8"
 description = "mSCP security baseline schema definitions"
 edition.workspace = true
 authors.workspace = true

--- a/crates/mscp/Cargo.toml
+++ b/crates/mscp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mscp"
-version = "0.1.7"
+version = "0.1.8"
 description = "Post-process mSCP output into MDM-ready configurations"
 edition.workspace = true
 authors.workspace = true

--- a/crates/mscp/src/cli/config_generate.rs
+++ b/crates/mscp/src/cli/config_generate.rs
@@ -1,7 +1,109 @@
 use crate::cli::generate::{PythonMethod, generate_baseline, switch_branch};
-use crate::config::{Config, OutputStructure};
-use crate::transformers::ScriptMode;
+use crate::config::{BaselineConfig, Config, OutputStructure};
+use crate::transformers::{
+    JamfOptions, MunkiComplianceOptions, MunkiScriptOptions, ProfileOptions, ScriptMode,
+};
 use anyhow::Result;
+
+/// Bundle of options derived from a [`Config`] + [`BaselineConfig`] for a single baseline.
+#[derive(Debug)]
+pub struct ConfigDerivedOptions {
+    pub profile_options: Option<ProfileOptions>,
+    pub jamf_options: Option<JamfOptions>,
+    pub munki_compliance_options: Option<MunkiComplianceOptions>,
+    pub munki_script_options: Option<MunkiScriptOptions>,
+    pub fleet_mode: bool,
+    pub no_labels: bool,
+    pub structure: OutputStructure,
+    pub jamf_exclude_conflicts: bool,
+    pub generate_ddm: bool,
+    pub team_names: Option<Vec<String>>,
+}
+
+/// Build option bundle from config for a single baseline.
+/// Mirrors the per-baseline mapping in [`generate_from_config`], factored out
+/// so the single-baseline `Generate` command can reuse it.
+pub fn build_options_from_config(
+    config: &Config,
+    baseline_config: &BaselineConfig,
+) -> ConfigDerivedOptions {
+    let structure = config.output.structure.clone();
+
+    let has_profile_opts = !config.settings.organization.name.is_empty()
+        || config.settings.jamf.remove_consent_text
+        || config.settings.jamf.consent_text.is_some()
+        || config.settings.jamf.deterministic_uuids;
+    let profile_options = if has_profile_opts {
+        Some(ProfileOptions {
+            org_name: if config.settings.organization.name.is_empty() {
+                None
+            } else {
+                Some(config.settings.organization.name.clone())
+            },
+            remove_consent_text: config.settings.jamf.remove_consent_text,
+            consent_text: config.settings.jamf.consent_text.clone(),
+            deterministic_uuids: config.settings.jamf.deterministic_uuids,
+        })
+    } else {
+        None
+    };
+
+    // Auto-enable Jamf options when structure is Flat (even without settings.jamf.enabled)
+    let jamf_enabled = config.settings.jamf.enabled || structure == OutputStructure::Flat;
+    let jamf_options = if jamf_enabled {
+        Some(JamfOptions {
+            no_creation_date: config.settings.jamf.no_creation_date,
+            identical_payload_uuid: config.settings.jamf.identical_payload_uuid,
+            baseline: Some(baseline_config.name.clone()),
+            domain: Some(config.settings.organization.domain.clone()),
+            org_name: Some(config.settings.organization.name.clone()),
+            description_format: config.settings.jamf.description_format.clone(),
+        })
+    } else {
+        None
+    };
+
+    // Auto-enable Munki options when structure is Nested (even without explicit flags)
+    let munki_compliance_enabled =
+        config.settings.munki.compliance_flags || structure == OutputStructure::Nested;
+    let munki_compliance_options = if munki_compliance_enabled {
+        Some(MunkiComplianceOptions {
+            target_path: std::path::PathBuf::from(&config.settings.munki.compliance_path),
+            flag_prefix: config.settings.munki.flag_prefix.clone(),
+        })
+    } else {
+        None
+    };
+
+    let munki_script_enabled =
+        config.settings.munki.script_nopkg || structure == OutputStructure::Nested;
+    let munki_script_options = if munki_script_enabled {
+        Some(MunkiScriptOptions {
+            catalog: config.settings.munki.catalog.clone(),
+            category: config.settings.munki.category.clone(),
+            display_name_prefix: "mSCP".to_string(),
+            embed_fix_in_installcheck: !config.settings.munki.separate_postinstall,
+        })
+    } else {
+        None
+    };
+
+    // Fleet mode enabled when structure is pluggable or explicitly enabled
+    let fleet_mode = config.settings.fleet.enabled || structure == OutputStructure::Pluggable;
+
+    ConfigDerivedOptions {
+        profile_options,
+        jamf_options,
+        munki_compliance_options,
+        munki_script_options,
+        fleet_mode,
+        no_labels: config.settings.fleet.no_labels,
+        structure,
+        jamf_exclude_conflicts: config.settings.jamf.exclude_conflicts,
+        generate_ddm: config.settings.generate_ddm,
+        team_names: baseline_config.team.as_ref().map(|t| vec![t.clone()]),
+    }
+}
 
 /// Generate baselines from config file
 pub fn generate_from_config(config: Config) -> Result<()> {
@@ -49,98 +151,29 @@ pub fn generate_from_config(config: Config) -> Result<()> {
             switch_branch(&config.settings.mscp_repo, target_branch)?;
         }
 
-        // Build ProfileOptions from config (general profile transforms, apply in any mode)
-        let has_profile_opts = !config.settings.organization.name.is_empty()
-            || config.settings.jamf.remove_consent_text
-            || config.settings.jamf.consent_text.is_some()
-            || config.settings.jamf.deterministic_uuids;
-        let profile_options = if has_profile_opts {
-            Some(crate::transformers::ProfileOptions {
-                org_name: if config.settings.organization.name.is_empty() {
-                    None
-                } else {
-                    Some(config.settings.organization.name.clone())
-                },
-                remove_consent_text: config.settings.jamf.remove_consent_text,
-                consent_text: config.settings.jamf.consent_text.clone(),
-                deterministic_uuids: config.settings.jamf.deterministic_uuids,
-            })
-        } else {
-            None
-        };
-
-        let structure = config.output.structure.clone();
-
-        // Auto-enable Jamf options when structure is Flat (even without settings.jamf.enabled)
-        let jamf_enabled = config.settings.jamf.enabled || structure == OutputStructure::Flat;
-
-        // Build Jamf options from config
-        let jamf_options = if jamf_enabled {
-            Some(crate::transformers::JamfOptions {
-                no_creation_date: config.settings.jamf.no_creation_date,
-                identical_payload_uuid: config.settings.jamf.identical_payload_uuid,
-                baseline: Some(baseline_config.name.clone()),
-                domain: Some(config.settings.organization.domain.clone()),
-                org_name: Some(config.settings.organization.name.clone()),
-                description_format: config.settings.jamf.description_format.clone(),
-            })
-        } else {
-            None
-        };
-
-        // Auto-enable Munki options when structure is Nested (even without explicit flags)
-        let munki_compliance_enabled =
-            config.settings.munki.compliance_flags || structure == OutputStructure::Nested;
-
-        // Build Munki compliance options from config
-        let munki_compliance_options = if munki_compliance_enabled {
-            Some(crate::transformers::MunkiComplianceOptions {
-                target_path: std::path::PathBuf::from(&config.settings.munki.compliance_path),
-                flag_prefix: config.settings.munki.flag_prefix.clone(),
-            })
-        } else {
-            None
-        };
-
-        let munki_script_enabled =
-            config.settings.munki.script_nopkg || structure == OutputStructure::Nested;
-
-        // Build Munki script options from config
-        let munki_script_options = if munki_script_enabled {
-            Some(crate::transformers::MunkiScriptOptions {
-                catalog: config.settings.munki.catalog.clone(),
-                category: config.settings.munki.category.clone(),
-                display_name_prefix: "mSCP".to_string(),
-                embed_fix_in_installcheck: !config.settings.munki.separate_postinstall,
-            })
-        } else {
-            None
-        };
-
-        // Fleet mode is enabled when structure is pluggable or explicitly enabled
-        let fleet_mode = config.settings.fleet.enabled || structure == OutputStructure::Pluggable;
+        let opts = build_options_from_config(&config, baseline_config);
 
         generate_baseline(
             config.settings.mscp_repo.clone(),
             baseline_config.name.clone(),
             config.settings.output_dir.clone(),
             python_method,
-            profile_options,
-            jamf_options,
-            munki_compliance_options,
-            munki_script_options,
-            config.settings.fleet.no_labels,
-            baseline_config.team.as_ref().map(|t| vec![t.clone()]), // team_names from config
-            fleet_mode,
-            config.settings.jamf.exclude_conflicts,
-            config.settings.generate_ddm,     // generate_ddm from config
-            false,                            // dry_run - always false for config-based generation
+            opts.profile_options,
+            opts.jamf_options,
+            opts.munki_compliance_options,
+            opts.munki_script_options,
+            opts.no_labels,
+            opts.team_names,
+            opts.fleet_mode,
+            opts.jamf_exclude_conflicts,
+            opts.generate_ddm,
+            false, // dry_run - always false for config-based generation
             crate::output::OutputMode::Human, // Always use human output for config-based generation
-            false,               // batch_mode - false for config-based individual generation
+            false, // batch_mode - false for config-based individual generation
             ScriptMode::Bundled, // Default to bundled mode for config-based generation
-            None,                // exclude_categories - not supported in config-based generation
-            false,               // fragment - not supported in config-based generation
-            structure.clone(),
+            None,  // exclude_categories - not supported in config-based generation
+            false, // fragment - not supported in config-based generation
+            opts.structure,
         )?;
     }
 

--- a/crates/mscp/src/cli/init.rs
+++ b/crates/mscp/src/cli/init.rs
@@ -406,19 +406,12 @@ pub fn init_project<P: AsRef<Path>>(
                 .map(|s| s.as_str())
                 .unwrap_or("cis_lvl1");
             println!("  1. Review and edit mscp.toml");
-            if final_jamf {
-                println!(
-                    "  2. Run: {} generate --mscp-repo ./macos_security --baseline {} --output ./output --jamf-mode",
-                    "contour mscp".cyan(),
-                    example_baseline
-                );
-            } else {
-                println!(
-                    "  2. Run: {} generate --mscp-repo ./macos_security --baseline {} --output ./output",
-                    "contour mscp".cyan(),
-                    example_baseline
-                );
-            }
+            println!(
+                "  2. Run: {} generate --config ./mscp.toml --mscp-repo ./macos_security --baseline {} --output ./output",
+                "contour mscp".cyan(),
+                example_baseline
+            );
+            println!("     (--config picks up [settings.munki]/[settings.jamf]/[settings.fleet])");
         } else {
             println!("  1. Clone mSCP: git clone https://github.com/usnistgov/macos_security.git");
             println!("  2. Or re-run with: contour mscp init --sync --branch {branch}");

--- a/crates/mscp/src/cli/mod.rs
+++ b/crates/mscp/src/cli/mod.rs
@@ -254,6 +254,12 @@ pub enum Commands {
     /// Runs the mSCP Python generation script, then transforms the output
     /// into MDM-ready configurations. This is the standard workflow.
     Generate {
+        /// Path to mscp.toml configuration file. When set, `[settings.munki]`,
+        /// `[settings.jamf]`, `[settings.fleet]`, and `[output].structure` are
+        /// read from config instead of requiring CLI flags.
+        #[arg(short, long)]
+        config: Option<PathBuf>,
+
         /// Path to mSCP repository
         #[arg(short, long)]
         mscp_repo: PathBuf,

--- a/crates/mscp/src/cli/process.rs
+++ b/crates/mscp/src/cli/process.rs
@@ -6,10 +6,10 @@ use crate::managers::{ConstraintType, Constraints, build_exclusion_plan, discove
 use crate::models::Platform;
 use crate::output::{CommandResult, OutputMode, print_bar_chart};
 use crate::transformers::{
-    DdmTransformer, FleetPolicyGenerator, FleetScriptGenerator, FleetScriptOptions, JamfOptions,
-    JamfPostprocessor, LabelGenerator, MunkiComplianceGenerator, MunkiComplianceOptions,
-    MunkiScriptGenerator, MunkiScriptOptions, ProfileOptions, ProfilePostprocessor,
-    ProfileTransformer, ScriptMode, ScriptTransformer, TeamYamlGenerator,
+    DdmTransformer, FleetPolicyGenerator, JamfOptions, JamfPostprocessor, LabelGenerator,
+    MunkiComplianceGenerator, MunkiComplianceOptions, MunkiScriptGenerator, MunkiScriptOptions,
+    ProfileOptions, ProfilePostprocessor, ProfileTransformer, RuleScriptGenerator,
+    RuleScriptOptions, ScriptMode, ScriptTransformer, TeamYamlGenerator,
 };
 use crate::validators::ConflictDetector;
 use crate::versioning::{GitInfoExtractor, ManifestStore, ProfileInfo};
@@ -456,11 +456,10 @@ pub fn process_baseline(
     let mut script_paths = Vec::new();
 
     // Combined compliance script (traditional approach)
-    // Skip wrapper generation in Fleet mode with bundled/granular scripts — the wrappers
-    // reference a sibling compliance script via relative path, but Fleet uploads scripts
-    // individually (no directory structure), so the wrappers would fail at runtime.
-    // The bundled/granular scripts are self-contained and replace this functionality.
-    let skip_combined_wrappers = is_fleet_output && script_mode != ScriptMode::Combined;
+    // Skip wrapper generation when using bundled/granular scripts — the wrappers reference
+    // a sibling compliance script via relative path, which doesn't exist when the script
+    // generator writes self-contained categorized scripts. Applies to Fleet and Jamf alike.
+    let skip_combined_wrappers = script_mode != ScriptMode::Combined;
 
     if let Some(ref compliance_script) = baseline.compliance_script {
         if !dry_run && !skip_combined_wrappers {
@@ -476,10 +475,10 @@ pub fn process_baseline(
         }
     }
 
-    // Individual per-rule scripts (granular/bundled mode)
-    // Generate when script_mode is not Combined and we're in Fleet output mode
-    // (per-rule scripts are Fleet-specific)
-    let should_generate_individual_scripts = is_fleet_output && script_mode != ScriptMode::Combined;
+    // Categorized per-rule scripts (granular/bundled mode) — platform-agnostic, works for
+    // both Fleet and Jamf. Emits self-contained bash scripts grouped by rule category
+    // (audit/os/system_settings).
+    let should_generate_individual_scripts = script_mode != ScriptMode::Combined;
 
     if should_generate_individual_scripts {
         let rules = if let Some(ref repo_path) = mscp_repo_path {
@@ -496,22 +495,23 @@ pub fn process_baseline(
         } else {
             tracing::info!("Generating scripts in {:?} mode...", script_mode);
 
-            let fleet_script_generator = FleetScriptGenerator::new(FleetScriptOptions {
+            let rule_script_generator = RuleScriptGenerator::new(RuleScriptOptions {
                 mode: script_mode,
-                ..FleetScriptOptions::default()
+                ..RuleScriptOptions::default()
             });
 
             // Use different output directory for Jamf vs Fleet
             let scripts_dir = if is_jamf_mode {
                 output_path.join(&baseline.name).join("scripts")
             } else {
+                // Fleet v4.83+ GitOps: platforms/macos/scripts/{baseline}/
+                let layout = contour_core::fleet_layout::FleetLayout::default();
                 output_path
-                    .join("lib/mscp")
+                    .join(layout.macos_scripts_subdir)
                     .join(&baseline.name)
-                    .join("scripts")
             };
 
-            let generated = fleet_script_generator.generate_for_baseline(
+            let generated = rule_script_generator.generate_for_baseline(
                 &rules,
                 &baseline.name,
                 &scripts_dir,
@@ -542,10 +542,11 @@ pub fn process_baseline(
         };
 
         let policy_generator = FleetPolicyGenerator::new(&baseline.name);
+        // Fleet v4.83+ GitOps: platforms/macos/policies/{baseline}/
+        let layout = contour_core::fleet_layout::FleetLayout::default();
         let policies_dir = output_path
-            .join("lib/mscp")
-            .join(&baseline.name)
-            .join("policies");
+            .join(layout.macos_policies_subdir)
+            .join(&baseline.name);
 
         let (policies, p_path) = policy_generator.generate_for_baseline(
             &rules,
@@ -576,7 +577,7 @@ pub fn process_baseline(
             // Fragment mode: generate minimal structure for merge
             tracing::info!("Fragment mode: generating Fleet fragment...");
 
-            // Generate baseline component (lib/mscp/{baseline}/baseline.toml)
+            // Generate baseline component (mscp/{baseline}/baseline.toml)
             let team_generator = TeamYamlGenerator::new(&output_path);
             let baseline_config = team_generator.generate_baseline_component(
                 &baseline,
@@ -603,6 +604,7 @@ pub fn process_baseline(
             tracing::info!("Team YAML written to: {}", team_yml_path.display());
 
             // Generate labels (needed for fragment default.yml)
+            let layout = contour_core::fleet_layout::FleetLayout::default();
             let mut label_paths = Vec::new();
             if !no_labels {
                 let label_generator = LabelGenerator::new(&output_path);
@@ -611,8 +613,8 @@ pub fn process_baseline(
                 let label_path = label_generator.write_labels(&baseline.name, &labels)?;
                 tracing::info!("Label definitions written to: {}", label_path.display());
                 label_paths.push(format!(
-                    "./lib/all/labels/mscp-{}.labels.yml",
-                    baseline.name
+                    "./{}/mscp-{}.labels.yml",
+                    layout.labels_dir, baseline.name
                 ));
             }
 
@@ -626,7 +628,10 @@ pub fn process_baseline(
                     let filename = p.file_name().and_then(|s| s.to_str()).unwrap_or_default();
                     let label_name = format!("mscp-{}", baseline.name);
                     contour_core::fragment::ProfileEntry {
-                        path: format!("../lib/mscp/{}/profiles/{filename}", baseline.name),
+                        path: format!(
+                            "../{}/{}/{filename}",
+                            layout.macos_profiles_subdir, baseline.name
+                        ),
                         labels_include_all: Some(vec![label_name]),
                         labels_include_any: None,
                         labels_exclude_any: None,
@@ -639,29 +644,41 @@ pub fn process_baseline(
             {
                 let policy_filename = p.file_name().and_then(|s| s.to_str()).unwrap_or_default();
                 vec![contour_core::fragment::SimpleEntry {
-                    path: format!("../lib/mscp/{}/policies/{policy_filename}", baseline.name),
+                    path: format!(
+                        "../{}/{}/{policy_filename}",
+                        layout.macos_policies_subdir, baseline.name
+                    ),
                 }]
             } else {
                 Vec::new()
             };
 
-            // Collect lib files (all files under lib/)
-            let lib_dir = output_path.join("lib");
-            let lib_files: Vec<String> = if lib_dir.exists() {
-                walkdir::WalkDir::new(&lib_dir)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter(|e| e.file_type().is_file())
-                    .filter_map(|e| {
-                        e.path()
-                            .strip_prefix(&output_path)
-                            .ok()
-                            .map(|p| p.to_string_lossy().to_string())
-                    })
-                    .collect()
-            } else {
-                Vec::new()
-            };
+            // Collect all fragment artifact files (platforms/, mscp/, labels/)
+            let fragment_roots = [
+                layout.platforms_dir.to_string(),
+                "mscp".to_string(),
+                layout.labels_dir.to_string(),
+            ];
+            let lib_files: Vec<String> = fragment_roots
+                .iter()
+                .flat_map(|root| {
+                    let root_dir = output_path.join(root);
+                    if !root_dir.exists() {
+                        return Vec::new();
+                    }
+                    walkdir::WalkDir::new(&root_dir)
+                        .into_iter()
+                        .filter_map(|e| e.ok())
+                        .filter(|e| e.file_type().is_file())
+                        .filter_map(|e| {
+                            e.path()
+                                .strip_prefix(&output_path)
+                                .ok()
+                                .map(|p| p.to_string_lossy().to_string())
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
 
             // Generate fragment.toml
             gitops_generator.generate_fragment_toml(
@@ -680,10 +697,12 @@ pub fn process_baseline(
             } else {
                 tracing::info!("Generating Fleet GitOps global structure...");
                 gitops_generator.generate_structure()?;
-                tracing::info!("Generated default.yml, lib/agent-options.yml, fleets/no-team.yml");
+                tracing::info!(
+                    "Generated default.yml, platforms/all/agent-options.yml, fleets/unassigned.yml"
+                );
             }
 
-            // Generate baseline component (lib/mscp/{baseline}/baseline.toml)
+            // Generate baseline component (mscp/{baseline}/baseline.toml)
             tracing::info!("Generating baseline component...");
             let team_generator = TeamYamlGenerator::new(&output_path);
             let baseline_config = team_generator.generate_baseline_component(
@@ -721,8 +740,9 @@ pub fn process_baseline(
                 tracing::info!("Label definitions written to: {}", label_path.display());
 
                 // Add label reference to default.yml
+                let layout = contour_core::fleet_layout::FleetLayout::default();
                 let relative_label_path =
-                    format!("./lib/all/labels/mscp-{}.labels.yml", baseline.name);
+                    format!("./{}/mscp-{}.labels.yml", layout.labels_dir, baseline.name);
                 if let Err(e) = gitops_generator.add_label_to_default_yml(&relative_label_path) {
                     tracing::warn!(
                         "Could not add labels to default.yml: {}. Add manually if needed.",

--- a/crates/mscp/src/main.rs
+++ b/crates/mscp/src/main.rs
@@ -191,6 +191,7 @@ fn main() -> Result<()> {
         }
 
         Commands::Generate {
+            config: config_path,
             mscp_repo,
             branch,
             baseline,
@@ -226,10 +227,6 @@ fn main() -> Result<()> {
             script_mode,
             fragment,
         } => {
-            // Resolve org from CLI flags, falling back to .contour/config.toml
-            let org = resolve_org(org);
-            let org_name = resolve_org_name(org_name);
-
             let python_method = if use_container {
                 Some(cli::generate::PythonMethod::Container)
             } else if use_uv {
@@ -239,6 +236,78 @@ fn main() -> Result<()> {
             } else {
                 None // Auto-detect
             };
+
+            // Determine output mode
+            let output_mode = if cli.json {
+                output::OutputMode::Json
+            } else {
+                output::OutputMode::Human
+            };
+
+            // Config-driven generation: load mscp.toml, derive options for this baseline.
+            if let Some(config_file) = config_path {
+                let loaded_config = config::load_config(&config_file)?;
+
+                // Find the requested baseline in the config (CLI --baseline selects which one)
+                let baseline_config = loaded_config
+                    .baselines
+                    .iter()
+                    .find(|b| b.name == baseline)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "baseline '{}' not found in {}; enabled baselines: {}",
+                            baseline,
+                            config_file.display(),
+                            loaded_config
+                                .baselines
+                                .iter()
+                                .map(|b| b.name.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    })?;
+
+                let opts = cli::config_generate::build_options_from_config(
+                    &loaded_config,
+                    baseline_config,
+                );
+
+                // Switch branch if specified in config for this baseline
+                if let Some(ref target_branch) = baseline_config.branch {
+                    cli::generate::switch_branch(&mscp_repo, target_branch)?;
+                } else if let Some(ref target_branch) = branch {
+                    cli::generate::switch_branch(&mscp_repo, target_branch)?;
+                }
+
+                cli::generate_baseline(
+                    mscp_repo,
+                    baseline,
+                    output,
+                    python_method,
+                    opts.profile_options,
+                    opts.jamf_options,
+                    opts.munki_compliance_options,
+                    opts.munki_script_options,
+                    opts.no_labels,
+                    opts.team_names,
+                    opts.fleet_mode,
+                    opts.jamf_exclude_conflicts,
+                    opts.generate_ddm,
+                    dry_run,
+                    output_mode,
+                    false, // batch_mode = false for single baseline
+                    script_mode.into(),
+                    exclude,
+                    fragment,
+                    opts.structure,
+                )?;
+                return Ok(());
+            }
+
+            // CLI-flag-driven generation (existing behavior when no --config)
+            // Resolve org from CLI flags, falling back to .contour/config.toml
+            let org = resolve_org(org);
+            let org_name = resolve_org_name(org_name);
             let deterministic_uuids = resolve_deterministic_uuids(deterministic_uuids);
 
             // Build ProfileOptions when any general profile option is set
@@ -299,13 +368,6 @@ fn main() -> Result<()> {
             if let Some(target_branch) = branch {
                 cli::generate::switch_branch(&mscp_repo, &target_branch)?;
             }
-
-            // Determine output mode
-            let output_mode = if cli.json {
-                output::OutputMode::Json
-            } else {
-                output::OutputMode::Human
-            };
 
             cli::generate_baseline(
                 mscp_repo,

--- a/crates/mscp/src/transformers/labels.rs
+++ b/crates/mscp/src/transformers/labels.rs
@@ -1,5 +1,6 @@
 use crate::models::Platform;
 use anyhow::Result;
+use contour_core::fleet_layout::FleetLayout;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -36,12 +37,14 @@ pub struct LabelSpec {
 #[derive(Debug)]
 pub struct LabelGenerator {
     output_base: PathBuf,
+    layout: FleetLayout,
 }
 
 impl LabelGenerator {
     pub fn new<P: AsRef<Path>>(output_base: P) -> Self {
         Self {
             output_base: output_base.as_ref().to_path_buf(),
+            layout: FleetLayout::default(),
         }
     }
 
@@ -90,9 +93,9 @@ impl LabelGenerator {
         Ok(labels)
     }
 
-    /// Write labels to lib/all/labels/mscp-{baseline}.labels.yml
+    /// Write labels to {layout.labels_dir}/mscp-{baseline}.labels.yml
     pub fn write_labels(&self, baseline_name: &str, labels: &[FleetLabel]) -> Result<PathBuf> {
-        let labels_dir = self.output_base.join("lib/all/labels");
+        let labels_dir = self.output_base.join(self.layout.labels_dir);
         std::fs::create_dir_all(&labels_dir)?;
 
         let filename = format!("mscp-{baseline_name}.labels.yml");

--- a/crates/mscp/src/transformers/mod.rs
+++ b/crates/mscp/src/transformers/mod.rs
@@ -1,6 +1,5 @@
 pub mod ddm;
 pub mod fleet_policy;
-pub mod fleet_script;
 pub mod jamf;
 pub mod jamf_scoping;
 pub mod labels;
@@ -8,18 +7,19 @@ pub mod munki_compliance;
 pub mod munki_pkginfo;
 pub mod munki_script;
 pub mod profile;
+pub mod rule_script;
 pub mod script;
 pub mod script_helpers;
 pub mod team_yaml;
 
 pub use ddm::*;
 pub use fleet_policy::*;
-pub use fleet_script::*;
 pub use jamf::*;
 pub use jamf_scoping::*;
 pub use labels::*;
 pub use munki_compliance::*;
 pub use munki_script::*;
 pub use profile::*;
+pub use rule_script::*;
 pub use script::*;
 pub use team_yaml::*;

--- a/crates/mscp/src/transformers/profile.rs
+++ b/crates/mscp/src/transformers/profile.rs
@@ -1,5 +1,6 @@
 use crate::models::MscpBaseline;
 use anyhow::Result;
+use contour_core::fleet_layout::FleetLayout;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -9,6 +10,7 @@ pub struct ProfileTransformer {
     output_base: PathBuf,
     jamf_mode: bool,
     fleet_output: bool,
+    layout: FleetLayout,
 }
 
 impl ProfileTransformer {
@@ -17,6 +19,7 @@ impl ProfileTransformer {
             output_base: output_base.as_ref().to_path_buf(),
             jamf_mode,
             fleet_output,
+            layout: FleetLayout::default(),
         }
     }
 
@@ -30,12 +33,10 @@ impl ProfileTransformer {
             // Jamf mode: Direct structure {output}/{baseline_name}/
             self.output_base.join(&baseline.name)
         } else if self.fleet_output {
-            // Fleet mode: GitOps structure lib/mscp/{baseline_name}/profiles/
+            // Fleet v4.83+ GitOps: platforms/macos/configuration-profiles/{baseline}/
             self.output_base
-                .join("lib")
-                .join("mscp")
+                .join(self.layout.macos_profiles_subdir)
                 .join(&baseline.name)
-                .join("profiles")
         } else {
             // Plain mode: mscp/{baseline_name}/profiles/
             self.output_base

--- a/crates/mscp/src/transformers/rule_script.rs
+++ b/crates/mscp/src/transformers/rule_script.rs
@@ -22,9 +22,9 @@ pub enum ScriptMode {
     Both,
 }
 
-/// Options for Fleet script generation
+/// Options for rule-based script generation (platform-agnostic)
 #[derive(Debug, Clone)]
-pub struct FleetScriptOptions {
+pub struct RuleScriptOptions {
     /// Script generation mode
     pub mode: ScriptMode,
 
@@ -33,7 +33,7 @@ pub struct FleetScriptOptions {
     pub script_prefix: String,
 }
 
-impl Default for FleetScriptOptions {
+impl Default for RuleScriptOptions {
     fn default() -> Self {
         Self {
             mode: ScriptMode::Bundled,
@@ -42,14 +42,15 @@ impl Default for FleetScriptOptions {
     }
 }
 
-/// Generator for individual Fleet scripts from mSCP script rules
+/// Generator for self-contained bash scripts from mSCP rules, grouped by category.
+/// Platform-agnostic — output works for Fleet, Jamf, Munki, or any MDM that runs bash.
 #[derive(Debug)]
-pub struct FleetScriptGenerator {
-    options: FleetScriptOptions,
+pub struct RuleScriptGenerator {
+    options: RuleScriptOptions,
 }
 
-impl FleetScriptGenerator {
-    pub fn new(options: FleetScriptOptions) -> Self {
+impl RuleScriptGenerator {
+    pub fn new(options: RuleScriptOptions) -> Self {
         Self { options }
     }
 
@@ -240,7 +241,7 @@ impl FleetScriptGenerator {
 
             ScriptMode::Granular => {
                 tracing::info!(
-                    "Generating {} individual Fleet scripts for baseline '{}'",
+                    "Generating {} individual scripts for baseline '{}'",
                     script_rules.len(),
                     baseline_name
                 );
@@ -281,7 +282,7 @@ impl FleetScriptGenerator {
                 }
 
                 tracing::info!(
-                    "Generating {} bundled Fleet script categories for baseline '{}'",
+                    "Generating {} bundled script categories for baseline '{}'",
                     categories.len(),
                     baseline_name
                 );
@@ -313,12 +314,12 @@ impl FleetScriptGenerator {
             ScriptMode::Both => {
                 // Generate both bundled and granular
                 tracing::info!(
-                    "Generating both bundled and granular Fleet scripts for baseline '{}'",
+                    "Generating both bundled and granular scripts for baseline '{}'",
                     baseline_name
                 );
 
                 // First generate bundled
-                let bundled_generator = FleetScriptGenerator::new(FleetScriptOptions {
+                let bundled_generator = RuleScriptGenerator::new(RuleScriptOptions {
                     mode: ScriptMode::Bundled,
                     ..self.options.clone()
                 });
@@ -327,7 +328,7 @@ impl FleetScriptGenerator {
                 generated.extend(bundled);
 
                 // Then generate granular
-                let granular_generator = FleetScriptGenerator::new(FleetScriptOptions {
+                let granular_generator = RuleScriptGenerator::new(RuleScriptOptions {
                     mode: ScriptMode::Granular,
                     ..self.options.clone()
                 });
@@ -354,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_generate_audit_script() {
-        let generator = FleetScriptGenerator::new(FleetScriptOptions::default());
+        let generator = RuleScriptGenerator::new(RuleScriptOptions::default());
         let rule = create_test_rule();
 
         let script = generator.generate_audit_script(&rule).unwrap();
@@ -367,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_generate_remediate_script() {
-        let generator = FleetScriptGenerator::new(FleetScriptOptions::default());
+        let generator = RuleScriptGenerator::new(RuleScriptOptions::default());
         let rule = create_test_rule();
 
         let script = generator.generate_remediate_script(&rule).unwrap();

--- a/crates/mscp/src/transformers/script.rs
+++ b/crates/mscp/src/transformers/script.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use contour_core::fleet_layout::FleetLayout;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -8,6 +9,7 @@ pub struct ScriptTransformer {
     output_base: PathBuf,
     jamf_mode: bool,
     fleet_output: bool,
+    layout: FleetLayout,
 }
 
 impl ScriptTransformer {
@@ -16,6 +18,7 @@ impl ScriptTransformer {
             output_base: output_base.as_ref().to_path_buf(),
             jamf_mode,
             fleet_output,
+            layout: FleetLayout::default(),
         }
     }
 
@@ -31,12 +34,10 @@ impl ScriptTransformer {
             // Jamf mode: Direct structure {output}/{baseline_name}/scripts/
             self.output_base.join(baseline_name).join("scripts")
         } else if self.fleet_output {
-            // Fleet mode: GitOps structure lib/mscp/{baseline_name}/scripts/
+            // Fleet v4.83+ GitOps: platforms/macos/scripts/{baseline}/
             self.output_base
-                .join("lib")
-                .join("mscp")
+                .join(self.layout.macos_scripts_subdir)
                 .join(baseline_name)
-                .join("scripts")
         } else {
             // Plain mode: mscp/{baseline_name}/scripts/
             self.output_base

--- a/crates/mscp/src/transformers/team_yaml.rs
+++ b/crates/mscp/src/transformers/team_yaml.rs
@@ -104,14 +104,14 @@ impl TeamYamlGenerator {
         Ok(config)
     }
 
-    /// Write the baseline component to lib/mscp/{baseline}/baseline.toml
+    /// Write the baseline component to mscp/{baseline}/baseline.toml (Fleet v4.83+ top-level)
     pub fn write_baseline_component(
         &self,
         config: &FleetTeamConfig,
         baseline_name: &str,
         platform: Platform,
     ) -> Result<PathBuf> {
-        let baseline_dir = self.output_base.join("lib/mscp").join(baseline_name);
+        let baseline_dir = self.output_base.join("mscp").join(baseline_name);
         std::fs::create_dir_all(&baseline_dir)?;
 
         let file_path = baseline_dir.join("baseline.toml");
@@ -296,19 +296,19 @@ controls:
         self.write_team_yml(baseline_name)
     }
 
-    /// Generate relative path from lib/mscp/{baseline}/ directory
+    /// Generate relative path from mscp/{baseline}/baseline.toml to an artifact
+    /// under output_base. baseline.toml is two directories deep (mscp/{baseline}/),
+    /// so we prepend `../../` to the output-base-relative path.
     fn get_relative_path_from_lib(
         &self,
         absolute_path: &Path,
-        baseline_name: &str,
+        _baseline_name: &str,
     ) -> Result<String> {
-        let baseline_dir = self.output_base.join("lib/mscp").join(baseline_name);
-
         let relative = absolute_path
-            .strip_prefix(&baseline_dir)
+            .strip_prefix(&self.output_base)
             .unwrap_or(absolute_path);
 
-        Ok(format!("./{}", relative.display()))
+        Ok(format!("../../{}", relative.display()))
     }
 
     /// Generate relative path from output base (for backward compatibility)

--- a/crates/mscp/src/versioning/manifest.rs
+++ b/crates/mscp/src/versioning/manifest.rs
@@ -49,10 +49,9 @@ impl ManifestStore {
         Ok(manifest_path)
     }
 
-    /// Get the manifest file path
+    /// Get the manifest file path (mscp/versions/manifest.json, Fleet v4.83+ top-level)
     fn get_manifest_path(&self) -> PathBuf {
         self.output_base
-            .join("lib")
             .join("mscp")
             .join("versions")
             .join("manifest.json")

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notifications"
-version = "0.1.7"
+version = "0.1.8"
 description = "Notification settings profile toolkit for macOS"
 edition.workspace = true
 authors.workspace = true

--- a/crates/osquery-schema/Cargo.toml
+++ b/crates/osquery-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osquery-schema"
-version = "0.1.7"
+version = "0.1.8"
 description = "Osquery table and column schema definitions"
 edition.workspace = true
 authors.workspace = true

--- a/crates/pppc/Cargo.toml
+++ b/crates/pppc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pppc"
-version = "0.1.7"
+version = "0.1.8"
 description = "PPPC/TCC mobileconfig profile toolkit for macOS privacy permissions"
 edition.workspace = true
 authors.workspace = true

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "profile"
-version = "0.1.7"
+version = "0.1.8"
 description = "Apple configuration profile toolkit for MDM deployments"
 edition.workspace = true
 authors.workspace = true

--- a/crates/profile/src/cli/jamf_import.rs
+++ b/crates/profile/src/cli/jamf_import.rs
@@ -25,6 +25,7 @@ use colored::Colorize;
 use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 use walkdir::WalkDir;
 
 // ── Jamf YAML structures ────────────────────────────────────────────
@@ -86,6 +87,7 @@ pub fn handle_jamf_import(
     import_all: bool,
     output_mode: OutputMode,
 ) -> Result<()> {
+    let start = Instant::now();
     let source_path = Path::new(source);
 
     // Discover YAML files
@@ -188,6 +190,14 @@ pub fn handle_jamf_import(
         None
     };
 
+    // Org is required for Jamf imports (via --org, profile.toml, or .contour/config.toml)
+    let effective_org = effective_org.ok_or_else(|| {
+        anyhow::anyhow!(
+            "--org is required for Jamf imports (e.g., --org com.yourorg)\n\
+             Alternatively, set organization.domain in profile.toml or .contour/config.toml"
+        )
+    })?;
+
     // Resolve org name
     let effective_org_name = org_name
         .map(String::from)
@@ -205,9 +215,7 @@ pub fn handle_jamf_import(
             extracted.len().to_string().green()
         );
         println!("  Output directory:    {}", effective_output);
-        if let Some(org) = effective_org {
-            println!("  Organization:        {}", org);
-        }
+        println!("  Organization:        {}", effective_org);
         if let Some(ref name) = effective_org_name {
             println!("  Organization name:   {}", name);
         }
@@ -215,9 +223,7 @@ pub fn handle_jamf_import(
         println!("  Pipeline (per profile):");
         println!("    1. Extract plist from Jamf YAML");
         println!("    2. Write as formatted .mobileconfig");
-        if effective_org.is_some() {
-            println!("    3. Normalize identifiers");
-        }
+        println!("    3. Normalize identifiers");
         if regen_uuid {
             println!("    4. Regenerate UUIDs");
         }
@@ -300,7 +306,7 @@ pub fn handle_jamf_import(
         match process_extracted_profile(
             ep,
             &output_path,
-            effective_org,
+            Some(effective_org),
             effective_org_name.as_deref(),
             config,
             validate,
@@ -327,8 +333,11 @@ pub fn handle_jamf_import(
     }
 
     // Summary
+    let elapsed = start.elapsed();
+    let elapsed_display = contour_core::format_elapsed(elapsed);
     if output_mode == OutputMode::Human {
         print_batch_summary(&batch, "Jamf Import");
+        println!("  Completed in {elapsed_display}");
     } else {
         output_batch_json(&batch, "jamf_import")?;
     }
@@ -643,6 +652,45 @@ general:
         assert!(
             content.contains('\n'),
             "Should be multi-line (not minified)"
+        );
+    }
+
+    #[test]
+    fn test_jamf_import_requires_org() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml_path = dir.path().join("test-profile.yaml");
+
+        let yaml_content = r#"_meta:
+    schema_version: 1
+    cli_version: 1.4.0
+    resource_type: profiles
+general:
+    name: Dock Settings
+    payloads: |-
+        <?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>PayloadContent</key><array><dict><key>PayloadDisplayName</key><string>Dock</string><key>PayloadIdentifier</key><string>com.test.dock</string><key>PayloadType</key><string>com.apple.dock</string><key>PayloadUUID</key><string>A1B2C3D4-E5F6-7890-ABCD-EF1234567890</string><key>PayloadVersion</key><integer>1</integer></dict></array><key>PayloadDisplayName</key><string>Dock Settings</string><key>PayloadIdentifier</key><string>com.test.dock-profile</string><key>PayloadType</key><string>Configuration</string><key>PayloadUUID</key><string>12345678-1234-1234-1234-123456789012</string><key>PayloadVersion</key><integer>1</integer></dict></plist>
+"#;
+        fs::write(&yaml_path, yaml_content).unwrap();
+
+        let output_dir = dir.path().join("output");
+
+        let result = handle_jamf_import(
+            dir.path().to_str().unwrap(),
+            Some(output_dir.to_str().unwrap()),
+            None, // no org
+            None,
+            None,
+            true,
+            true,
+            false,
+            true,
+            OutputMode::Json,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("--org is required"),
+            "Error should mention --org requirement, got: {err}"
         );
     }
 }

--- a/crates/santa/Cargo.toml
+++ b/crates/santa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "santa"
-version = "0.1.7"
+version = "0.1.8"
 description = "Santa mobileconfig profile toolkit for macOS application control"
 edition.workspace = true
 authors.workspace = true

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "support"
-version = "0.1.7"
+version = "0.1.8"
 description = "Root3 Support App mobileconfig profile generator"
 edition.workspace = true
 authors.workspace = true

--- a/pkg/contour/build-info.toml
+++ b/pkg/contour/build-info.toml
@@ -1,6 +1,6 @@
-name = "contour-0.1.7.pkg"
+name = "contour-0.1.8.pkg"
 identifier = "io.declarative.contour.pkg"
-version = "0.1.7"
+version = "0.1.8"
 install_location = "/"
 
 [signing_info]


### PR DESCRIPTION
- Bump to v0.1.8
- Added ⁠--config option for mSCP generation and refactored related logic.
- Hookconfig-based flow into ⁠mscp::main and ⁠contour::dispatch. 
- Refactor to ⁠rule_script, and generalizing script generation across platforms. 
- Updated documentation and folder structure accordingly.